### PR TITLE
Core: Allow for config data to be passed along

### DIFF
--- a/eris/core.py
+++ b/eris/core.py
@@ -29,8 +29,11 @@ class Core(discord.Client):
         self.modules = {}
 
         # Load the configuration and validate it.
-        with open(config, 'r') as configfile:
-            cfg = json.load(configfile)
+        if isinstance(config, dict):
+            cfg = config
+        else:
+            with open(config, 'r') as configfile:
+                cfg = json.load(configfile)
         self.config = Config(cfg)
 
         AdminOnly.register_config(self.config)


### PR DESCRIPTION
This allows the callee to pass along the config data from different sources (such as a .yaml file) without having to add this complexity into Eris for every data source type. 

The PR maintains the current config loading behavior for existing implementations.